### PR TITLE
fix(durably-react): add isCancelled to client-mode useJob

### DIFF
--- a/.claude/skills/release-check/SKILL.md
+++ b/.claude/skills/release-check/SKILL.md
@@ -1,0 +1,129 @@
+---
+name: release-check
+description: Pre-release integrity check. Verify package consistency for API changes and spec updates. Use for release check, version update, documentation consistency, pre-release verification.
+allowed-tools:
+  - Read
+  - Grep
+  - Glob
+  - Bash(pnpm:*)
+  - Bash(git:*)
+---
+
+# Release Check
+
+Verify package integrity for API changes and spec updates.
+
+## 1. Implementation
+
+- [ ] **@coji/durably** (`packages/durably/src/`)
+- [ ] **@coji/durably-react** (`packages/durably-react/src/`)
+  - [ ] Browser hooks (`hooks/`)
+  - [ ] Client hooks (`client/`)
+  - [ ] Shared utilities (`shared/`)
+  - [ ] Type definitions (`types.ts`)
+
+## 2. Version Update
+
+- [ ] `packages/durably/package.json` - version
+- [ ] `packages/durably-react/package.json` - version
+
+## 3. Documentation
+
+### Core
+
+- [ ] `packages/durably/docs/llms.md` - LLM docs (bundled in npm)
+- [ ] `docs/spec.md` - Core specification
+
+### React
+
+- [ ] `packages/durably-react/docs/llms.md` - LLM docs (bundled in npm)
+- [ ] `docs/spec-react.md` - React specification
+- [ ] `website/api/durably-react/index.md` - Overview
+- [ ] `website/api/durably-react/browser.md` - Browser hooks
+- [ ] `website/api/durably-react/client.md` - Client hooks
+- [ ] `website/api/durably-react/types.md` - Type definitions
+
+### Website
+
+- [ ] `website/public/llms.txt` - Core + React llms.md concatenated (`pnpm --filter durably-website generate:llms`)
+
+## 4. README
+
+- [ ] `packages/durably/README.md`
+- [ ] `packages/durably-react/README.md`
+
+## 5. Examples
+
+- [ ] `examples/browser-vite-react/` - Browser mode example
+- [ ] `examples/browser-react-router-spa/` - Browser mode with React Router
+- [ ] `examples/fullstack-react-router/` - Client mode (server-connected)
+- [ ] `examples/server-node/` - Node.js server example
+
+## 6. Tests
+
+### Core (`packages/durably/tests/`)
+
+- [ ] `node/` - Node.js tests
+- [ ] `browser/` - Browser tests
+
+### React (`packages/durably-react/tests/`)
+
+- [ ] `types.test.ts` - Type tests
+
+Verify new features/changes are covered by tests.
+
+## 7. Changelog
+
+- [ ] `CHANGELOG.md` - Add version section
+
+## 8. Validation
+
+```bash
+pnpm format:fix  # Fix formatting first (Claude-written code often has format errors)
+pnpm lint:fix    # Fix lint issues
+pnpm --filter durably-website generate:llms  # Regenerate website/public/llms.txt
+pnpm validate    # Run format, lint, typecheck, test
+```
+
+Check `git status` for uncommitted changes.
+
+---
+
+## Common Oversights
+
+### Browser/Client Mode Consistency
+
+When React hooks should provide the same API in both Browser and Client modes:
+
+| File                  | Mode          |
+| --------------------- | ------------- |
+| `hooks/use-job.ts`    | Browser mode  |
+| `client/use-job.ts`   | Client mode   |
+
+Ensure consistency in:
+- Interface definitions
+- Return values
+- Options
+
+### Code Examples in Documentation
+
+Verify code examples in docs match actual API:
+- Return value properties
+- Option parameters
+- Type definitions
+
+### Type Exports
+
+Check if new types are exported in `index.ts` / `client.ts`.
+
+### Examples Consistency
+
+If examples use new API, verify no type errors or runtime errors:
+
+```bash
+pnpm typecheck  # Includes all examples
+```
+
+Key components to check:
+- `dashboard.tsx` - useRuns, useRunActions
+- `*-progress.tsx` - useJob return values (status booleans)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.8.1] - 2026-01-18
+
+### Added
+
+#### @coji/durably-react
+
+- **`isCancelled` state boolean for client-mode `useJob`**: Now consistent with browser-mode API
+  - Previously missing from client-mode hook, causing inconsistency between modes
+
 ## [0.8.0] - 2026-01-11
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,3 +79,7 @@ pnpm test          # Run all tests
 pnpm format        # Fix formatting
 pnpm lint:fix      # Fix lint issues
 ```
+
+## Skills
+
+- **release-check** - Pre-release integrity check for API changes and spec updates (`.claude/skills/release-check/`)

--- a/docs/spec-react.md
+++ b/docs/spec-react.md
@@ -303,6 +303,7 @@ const {
   isPending,
   isCompleted,
   isFailed,
+  isCancelled,
   currentRunId,
   reset,
 } = useJob(jobDefinition, options?)
@@ -331,6 +332,7 @@ const {
 | `isPending` | `boolean` | 待機中 |
 | `isCompleted` | `boolean` | 完了 |
 | `isFailed` | `boolean` | 失敗 |
+| `isCancelled` | `boolean` | キャンセル |
 | `currentRunId` | `string \| null` | 現在の Run ID |
 | `reset` | `() => void` | 状態リセット |
 
@@ -496,6 +498,7 @@ const {
   isPending,
   isCompleted,
   isFailed,
+  isCancelled,
   currentRunId,
   reset,
 } = useJob({

--- a/packages/durably-react/README.md
+++ b/packages/durably-react/README.md
@@ -74,10 +74,16 @@ For full-stack apps, use hooks from `@coji/durably-react/client`:
 import { useJob } from '@coji/durably-react/client'
 
 function MyComponent() {
-  const { trigger, status, output, isRunning } = useJob<
-    { id: string },
-    { result: number }
-  >({
+  const {
+    trigger,
+    status,
+    output,
+    isRunning,
+    isPending,
+    isCompleted,
+    isFailed,
+    isCancelled,
+  } = useJob<{ id: string }, { result: number }>({
     api: '/api/durably',
     jobName: 'my-job',
     autoResume: true, // Auto-resume running/pending jobs on mount (default)

--- a/packages/durably-react/docs/llms.md
+++ b/packages/durably-react/docs/llms.md
@@ -370,7 +370,10 @@ function Component() {
     logs,
     progress,
     isRunning,
+    isPending,
     isCompleted,
+    isFailed,
+    isCancelled,
     currentRunId,
     reset,
   } = useJob<

--- a/packages/durably-react/package.json
+++ b/packages/durably-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coji/durably-react",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "React bindings for Durably - step-oriented resumable batch execution",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/durably-react/src/client/use-job.ts
+++ b/packages/durably-react/src/client/use-job.ts
@@ -77,6 +77,10 @@ export interface UseJobClientResult<TInput, TOutput> {
    */
   isFailed: boolean
   /**
+   * Whether the run was cancelled
+   */
+  isCancelled: boolean
+  /**
    * Current run ID
    */
   currentRunId: string | null
@@ -285,6 +289,7 @@ export function useJob<
     isPending: effectiveStatus === 'pending',
     isCompleted: effectiveStatus === 'completed',
     isFailed: effectiveStatus === 'failed',
+    isCancelled: effectiveStatus === 'cancelled',
     currentRunId,
     reset,
   }

--- a/packages/durably/package.json
+++ b/packages/durably/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coji/durably",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Step-oriented resumable batch execution for Node.js and browsers using SQLite",
   "type": "module",
   "main": "./dist/index.js",

--- a/website/api/durably-react/browser.md
+++ b/website/api/durably-react/browser.md
@@ -107,6 +107,7 @@ function Component() {
     isPending,
     isCompleted,
     isFailed,
+    isCancelled,
     currentRunId,
     reset,
   } = useJob(myJob)
@@ -153,6 +154,7 @@ interface UseJobResult<TInput, TOutput> {
   isPending: boolean
   isCompleted: boolean
   isFailed: boolean
+  isCancelled: boolean
   currentRunId: string | null
   reset: () => void
 }
@@ -178,6 +180,7 @@ function RunMonitor({ runId }: { runId: string | null }) {
     isRunning,
     isCompleted,
     isFailed,
+    isCancelled,
   } = useJobRun<{ result: number }>({ runId })
 
   if (!runId) return <div>No run selected</div>

--- a/website/api/durably-react/client.md
+++ b/website/api/durably-react/client.md
@@ -103,7 +103,6 @@ import { useJob } from '@coji/durably-react/client'
 
 function Component() {
   const {
-    isReady,
     trigger,
     triggerAndWait,
     status,
@@ -112,7 +111,10 @@ function Component() {
     logs,
     progress,
     isRunning,
+    isPending,
     isCompleted,
+    isFailed,
+    isCancelled,
     currentRunId,
     reset,
   } = useJob<

--- a/website/public/llms.txt
+++ b/website/public/llms.txt
@@ -819,7 +819,10 @@ function Component() {
     logs,
     progress,
     isRunning,
+    isPending,
     isCompleted,
+    isFailed,
+    isCancelled,
     currentRunId,
     reset,
   } = useJob<
@@ -829,6 +832,8 @@ function Component() {
     api: '/api/durably',
     jobName: 'sync-data',
     initialRunId: undefined, // Optional: resume existing run
+    autoResume: true, // Auto-resume pending/running jobs on mount (default: true)
+    followLatest: true, // Switch to tracking new runs (default: true)
   })
 
   const handleClick = async () => {
@@ -839,6 +844,22 @@ function Component() {
   return <button onClick={handleClick}>Sync</button>
 }
 ```
+
+**Options:**
+
+```ts
+interface UseJobClientOptions {
+  api: string // API endpoint URL (e.g., '/api/durably')
+  jobName: string // Job name to trigger
+  initialRunId?: string // Initial Run ID to subscribe to
+  autoResume?: boolean // Auto-resume pending/running jobs on mount (default: true)
+  followLatest?: boolean // Switch to tracking new runs via SSE (default: true)
+}
+```
+
+The `autoResume` option automatically fetches running/pending jobs on mount and subscribes to them. This is useful for SSR applications where users may refresh the page while a job is running.
+
+The `followLatest` option subscribes to job-level SSE events and automatically switches to tracking the latest triggered job. This enables real-time updates when jobs are triggered from other tabs or clients.
 
 ### Client useJobRun
 


### PR DESCRIPTION
## Summary

- Client-mode `useJob` に `isCancelled` ステータスブーリアンを追加（Browser-mode との整合性を確保）
- `release-check` スキルを新規作成（API変更時のパッケージ整合性チェック用）
- 関連ドキュメント更新

## Changes

### Implementation
- `packages/durably-react/src/client/use-job.ts` - `isCancelled` 追加

### Documentation
- `packages/durably-react/docs/llms.md`
- `docs/spec-react.md`
- `website/api/durably-react/browser.md`
- `website/api/durably-react/client.md`
- `packages/durably-react/README.md`

### Tooling
- `.claude/skills/release-check/SKILL.md` - 新規作成
- `CLAUDE.md` - Skills セクション追加

### Version
- `packages/durably` → 0.8.1
- `packages/durably-react` → 0.8.1

## Test plan

- [x] `pnpm validate` 全パス
- [x] Browser/Client 両モードの useJob, useJobRun で `isCancelled` が利用可能

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `isCancelled` boolean flag to the `useJob` hook for tracking cancelled job states across all modes.
  * Introduced additional state flags (`isPending`, `isFailed`) to client-mode API for better consistency with browser-mode.

* **Documentation**
  * Updated API documentation to reflect new state flags and available options in all integration modes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->