### PR TITLE
fix(react): initialize isLoading as true in useRuns

### DIFF
--- a/packages/durably-react/src/client/use-runs.ts
+++ b/packages/durably-react/src/client/use-runs.ts
@@ -213,7 +213,7 @@ export function useRuns<
   const [runs, setRuns] = useState<TypedClientRun<TInput, TOutput>[]>([])
   const [page, setPage] = useState(0)
   const [hasMore, setHasMore] = useState(false)
-  const [isLoading, setIsLoading] = useState(false)
+  const [isLoading, setIsLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
 
   const isMountedRef = useRef(true)

--- a/packages/durably-react/src/hooks/use-runs.ts
+++ b/packages/durably-react/src/hooks/use-runs.ts
@@ -168,7 +168,7 @@ export function useRuns<
   const [runs, setRuns] = useState<TypedRun<TInput, TOutput>[]>([])
   const [page, setPage] = useState(0)
   const [hasMore, setHasMore] = useState(false)
-  const [isLoading, setIsLoading] = useState(false)
+  const [isLoading, setIsLoading] = useState(true)
 
   const refresh = useCallback(async () => {
     if (!durably) return


### PR DESCRIPTION
## Summary
- Initialize `isLoading` as `true` in both browser and client `useRuns` hooks
- Prevents flash of "No data" empty state before first fetch completes

Fixes #29

## Test plan
- [x] Existing test already expects `isLoading` to be `true` on initial render
- [x] TypeScript compiles without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the initial loading indicator state to display as active when the runs hook initializes, providing accurate feedback to users on load.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->