### PR TITLE
feat: add run:delete event for useRuns auto-refresh

### DIFF
--- a/packages/durably-react/src/client/use-runs.ts
+++ b/packages/durably-react/src/client/use-runs.ts
@@ -21,6 +21,7 @@ type RunUpdateEvent =
         | 'run:complete'
         | 'run:fail'
         | 'run:cancel'
+        | 'run:delete'
         | 'run:retry'
       runId: string
       jobName: string
@@ -296,6 +297,7 @@ export function useRuns<
           data.type === 'run:complete' ||
           data.type === 'run:fail' ||
           data.type === 'run:cancel' ||
+          data.type === 'run:delete' ||
           data.type === 'run:retry'
         ) {
           refresh()

--- a/packages/durably-react/src/hooks/use-runs.ts
+++ b/packages/durably-react/src/hooks/use-runs.ts
@@ -203,6 +203,7 @@ export function useRuns<
       durably.on('run:complete', refresh),
       durably.on('run:fail', refresh),
       durably.on('run:cancel', refresh),
+      durably.on('run:delete', refresh),
       durably.on('run:retry', refresh),
       durably.on('run:progress', refresh),
       durably.on('step:start', refresh),

--- a/packages/durably/docs/llms.md
+++ b/packages/durably/docs/llms.md
@@ -226,6 +226,7 @@ durably.on('run:start', (e) => console.log('Started:', e.runId))
 durably.on('run:complete', (e) => console.log('Done:', e.output))
 durably.on('run:fail', (e) => console.error('Failed:', e.error))
 durably.on('run:cancel', (e) => console.log('Cancelled:', e.runId))
+durably.on('run:delete', (e) => console.log('Deleted:', e.runId))
 durably.on('run:retry', (e) => console.log('Retried:', e.runId))
 durably.on('run:progress', (e) =>
   console.log('Progress:', e.progress.current, '/', e.progress.total),

--- a/packages/durably/src/durably.ts
+++ b/packages/durably/src/durably.ts
@@ -337,6 +337,15 @@ function createDurablyInstance<
             }
           })
 
+          const unsubscribeDelete = eventEmitter.on('run:delete', (event) => {
+            if (!closed && event.runId === runId) {
+              controller.enqueue(event)
+              closed = true
+              cleanup?.()
+              controller.close()
+            }
+          })
+
           const unsubscribeRetry = eventEmitter.on('run:retry', (event) => {
             if (!closed && event.runId === runId) {
               controller.enqueue(event)
@@ -388,6 +397,7 @@ function createDurablyInstance<
             unsubscribeComplete()
             unsubscribeFail()
             unsubscribeCancel()
+            unsubscribeDelete()
             unsubscribeRetry()
             unsubscribeProgress()
             unsubscribeStepStart()
@@ -473,6 +483,14 @@ function createDurablyInstance<
         throw new Error(`Cannot delete running run: ${runId}`)
       }
       await storage.deleteRun(runId)
+
+      // Emit run:delete event
+      eventEmitter.emit({
+        type: 'run:delete',
+        runId,
+        jobName: run.jobName,
+        labels: run.labels,
+      })
     },
 
     async migrate(): Promise<void> {

--- a/packages/durably/src/events.ts
+++ b/packages/durably/src/events.ts
@@ -64,6 +64,16 @@ export interface RunCancelEvent extends BaseEvent {
 }
 
 /**
+ * Run delete event (emitted when a run is deleted)
+ */
+export interface RunDeleteEvent extends BaseEvent {
+  type: 'run:delete'
+  runId: string
+  jobName: string
+  labels: Record<string, string>
+}
+
+/**
  * Run retry event (emitted when a failed run is retried)
  */
 export interface RunRetryEvent extends BaseEvent {
@@ -154,6 +164,7 @@ export type DurablyEvent =
   | RunCompleteEvent
   | RunFailEvent
   | RunCancelEvent
+  | RunDeleteEvent
   | RunRetryEvent
   | RunProgressEvent
   | StepStartEvent
@@ -192,6 +203,7 @@ export type AnyEventInput =
   | EventInput<'run:complete'>
   | EventInput<'run:fail'>
   | EventInput<'run:cancel'>
+  | EventInput<'run:delete'>
   | EventInput<'run:retry'>
   | EventInput<'run:progress'>
   | EventInput<'step:start'>

--- a/packages/durably/src/index.ts
+++ b/packages/durably/src/index.ts
@@ -20,6 +20,7 @@ export type {
   EventType,
   LogWriteEvent,
   RunCompleteEvent,
+  RunDeleteEvent,
   RunFailEvent,
   RunProgressEvent,
   RunStartEvent,

--- a/packages/durably/src/server.ts
+++ b/packages/durably/src/server.ts
@@ -440,6 +440,17 @@ export function createDurablyHandler(
             }
           }),
 
+          durably.on('run:delete', (event) => {
+            if (matchesFilter(event.jobName, event.labels)) {
+              ctrl.enqueue({
+                type: 'run:delete',
+                runId: event.runId,
+                jobName: event.jobName,
+                labels: event.labels,
+              })
+            }
+          }),
+
           durably.on('run:retry', (event) => {
             if (matchesFilter(event.jobName, event.labels)) {
               ctrl.enqueue({

--- a/packages/durably/tests/shared/events.shared.ts
+++ b/packages/durably/tests/shared/events.shared.ts
@@ -173,6 +173,28 @@ export function createEventsTests(createDialect: () => Dialect) {
       expect(completeListener).toHaveBeenCalledTimes(0)
     })
 
+    it('emits run:delete event with correct fields', () => {
+      const listener = vi.fn()
+      durably.on('run:delete', listener)
+
+      durably.emit({
+        type: 'run:delete',
+        runId: 'run_1',
+        jobName: 'test-job',
+        labels: { env: 'test' },
+      })
+
+      expect(listener).toHaveBeenCalledTimes(1)
+      expect(listener).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'run:delete',
+          runId: 'run_1',
+          jobName: 'test-job',
+          labels: { env: 'test' },
+        }),
+      )
+    })
+
     it('calls onError handler when listener throws', () => {
       const errorHandler = vi.fn()
       const failingListener = vi.fn(() => {

--- a/website/api/durably-react/browser.md
+++ b/website/api/durably-react/browser.md
@@ -257,7 +257,7 @@ List runs with optional filtering, pagination, and real-time updates.
 
 The hook automatically subscribes to Durably events and refreshes the list when runs change. It listens to:
 
-- `run:trigger`, `run:start`, `run:complete`, `run:fail`, `run:cancel`, `run:retry` - refresh list
+- `run:trigger`, `run:start`, `run:complete`, `run:fail`, `run:cancel`, `run:delete`, `run:retry` - refresh list
 - `run:progress` - update progress in place
 - `step:start`, `step:complete` - refresh for step count updates
 

--- a/website/api/durably-react/client.md
+++ b/website/api/durably-react/client.md
@@ -217,7 +217,7 @@ List and paginate job runs with real-time updates on the first page.
 
 The first page (page 0) automatically subscribes to SSE for real-time updates. It listens to:
 
-- `run:trigger`, `run:start`, `run:complete`, `run:fail`, `run:cancel`, `run:retry` - refresh list
+- `run:trigger`, `run:start`, `run:complete`, `run:fail`, `run:cancel`, `run:delete`, `run:retry` - refresh list
 - `run:progress` - update progress in place
 - `step:start`, `step:complete`, `step:fail` - refresh for step updates
 

--- a/website/api/events.md
+++ b/website/api/events.md
@@ -121,6 +121,23 @@ durably.on('run:cancel', (event) => {
 })
 ```
 
+#### `run:delete`
+
+Fired when a run is deleted via `deleteRun()` API.
+
+```ts
+durably.on('run:delete', (event) => {
+  // event: {
+  //   type: 'run:delete',
+  //   runId: string,
+  //   jobName: string,
+  //   labels: Record<string, string>,
+  //   timestamp: string,
+  //   sequence: number
+  // }
+})
+```
+
 #### `run:retry`
 
 Fired when a failed or cancelled run is retried via `retry()` API.

--- a/website/public/llms.txt
+++ b/website/public/llms.txt
@@ -226,6 +226,7 @@ durably.on('run:start', (e) => console.log('Started:', e.runId))
 durably.on('run:complete', (e) => console.log('Done:', e.output))
 durably.on('run:fail', (e) => console.error('Failed:', e.error))
 durably.on('run:cancel', (e) => console.log('Cancelled:', e.runId))
+durably.on('run:delete', (e) => console.log('Deleted:', e.runId))
 durably.on('run:retry', (e) => console.log('Retried:', e.runId))
 durably.on('run:progress', (e) =>
   console.log('Progress:', e.progress.current, '/', e.progress.total),


### PR DESCRIPTION
## Summary
- Add `run:delete` event type emitted when a run is deleted via `deleteRun()`
- Wire up SSE streaming and both `useRuns` hooks (browser + client) to auto-refresh on delete
- Makes delete consistent with cancel/retry, which already trigger auto-refresh

Closes #25

## Changes
- **`packages/durably/src/events.ts`** — `RunDeleteEvent` interface, added to `DurablyEvent` and `AnyEventInput` unions
- **`packages/durably/src/durably.ts`** — Emit `run:delete` in `deleteRun()`; add listener in `subscribe()` that closes the stream
- **`packages/durably/src/server.ts`** — Add `run:delete` to `runsSubscribe()` SSE endpoint
- **`packages/durably-react/src/client/use-runs.ts`** — Add `run:delete` to `RunUpdateEvent` and refresh trigger
- **`packages/durably-react/src/hooks/use-runs.ts`** — Add `durably.on('run:delete', refresh)`
- **Tests & docs** — Event test, API docs, React docs, regenerated `llms.txt`

## Test plan
- [x] `pnpm --filter durably typecheck` passes
- [x] `pnpm --filter durably-react typecheck` passes
- [x] `pnpm --filter durably test:node -- --run` — all event tests pass (1 pre-existing flaky worker test unrelated)
- [x] `pnpm format` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)