### PR TITLE
fix: include jobName and labels in log:write events for SSE filtering

### DIFF
--- a/packages/durably/src/context.ts
+++ b/packages/durably/src/context.ts
@@ -133,6 +133,8 @@ export function createStepContext(
         eventEmitter.emit({
           type: 'log:write',
           runId: run.id,
+          jobName,
+          labels: run.labels,
           stepName: currentStepName,
           level: 'info',
           message,
@@ -144,6 +146,8 @@ export function createStepContext(
         eventEmitter.emit({
           type: 'log:write',
           runId: run.id,
+          jobName,
+          labels: run.labels,
           stepName: currentStepName,
           level: 'warn',
           message,
@@ -155,6 +159,8 @@ export function createStepContext(
         eventEmitter.emit({
           type: 'log:write',
           runId: run.id,
+          jobName,
+          labels: run.labels,
           stepName: currentStepName,
           level: 'error',
           message,

--- a/packages/durably/src/events.ts
+++ b/packages/durably/src/events.ts
@@ -139,6 +139,8 @@ export interface StepFailEvent extends BaseEvent {
 export interface LogWriteEvent extends BaseEvent {
   type: 'log:write'
   runId: string
+  jobName: string
+  labels: Record<string, string>
   stepName: string | null
   level: 'info' | 'warn' | 'error'
   message: string

--- a/packages/durably/src/server.ts
+++ b/packages/durably/src/server.ts
@@ -515,12 +515,12 @@ export function createDurablyHandler(
           }),
 
           durably.on('log:write', (event) => {
-            // log:write doesn't have jobName or labels, so we can't filter by it
-            // Send all logs when no filter, or skip if filter is set
-            if (!jobNameFilter && !labelsFilter) {
+            if (matchesFilter(event.jobName, event.labels)) {
               ctrl.enqueue({
                 type: 'log:write',
                 runId: event.runId,
+                jobName: event.jobName,
+                labels: event.labels,
                 stepName: event.stepName,
                 level: event.level,
                 message: event.message,

--- a/website/api/events.md
+++ b/website/api/events.md
@@ -228,6 +228,8 @@ durably.on('log:write', (event) => {
   // event: {
   //   type: 'log:write',
   //   runId: string,
+  //   jobName: string,
+  //   labels: Record<string, string>,
   //   stepName: string | null,
   //   level: 'info' | 'warn' | 'error',
   //   message: string,


### PR DESCRIPTION
## Summary
- Add `jobName` and `labels` fields to `LogWriteEvent` interface, matching all other event types
- Include both fields when emitting `log:write` events from `step.log.info/warn/error()`
- Replace the skip-when-filtered workaround in `runsSubscribe()` with proper `matchesFilter()` call

Fixes #33

## Test plan
- [x] `pnpm --filter durably typecheck` passes
- [x] `pnpm --filter durably-react typecheck` passes
- [x] `pnpm --filter durably test:node -- --run` passes (182/183, 1 pre-existing flaky)
- [ ] Subscribe to `GET /runs/subscribe?jobName=X` and verify `log:write` events are received
- [ ] Subscribe with `label.*` filter and verify `log:write` events are filtered correctly
- [ ] Subscribe without filters and verify `log:write` events still arrive

🤖 Generated with [Claude Code](https://claude.com/claude-code)