### PR TITLE
fix: flaky sequential ordering test

### DIFF
--- a/packages/durably/src/storage.ts
+++ b/packages/durably/src/storage.ts
@@ -1,6 +1,8 @@
 import { type Kysely, sql } from 'kysely'
-import { ulid } from 'ulidx'
+import { monotonicFactory } from 'ulidx'
 import type { Database } from './schema'
+
+const ulid = monotonicFactory()
 
 /**
  * Run data for creating a new run

--- a/packages/durably/tests/shared/worker.shared.ts
+++ b/packages/durably/tests/shared/worker.shared.ts
@@ -193,11 +193,8 @@ export function createWorkerTests(createDialect: () => Dialect) {
         })
         const d = durably.register({ job: sequentialTestDef })
 
-        // Small delays ensure distinct ULID timestamps for deterministic ordering
         await d.jobs.job.trigger({ n: 1 })
-        await new Promise((r) => setTimeout(r, 2))
         await d.jobs.job.trigger({ n: 2 })
-        await new Promise((r) => setTimeout(r, 2))
         await d.jobs.job.trigger({ n: 3 })
 
         d.start()


### PR DESCRIPTION
## Summary
- Use `monotonicFactory()` from `ulidx` instead of plain `ulid()` for ID generation
- Monotonic ULID guarantees IDs are monotonically increasing within the same millisecond
- This fixes the flaky test **and** strengthens ordering guarantees in production when multiple runs are triggered in rapid succession

## Changes
- `packages/durably/src/storage.ts`: Replace `ulid` import with `monotonicFactory`
- `packages/durably/tests/shared/worker.shared.ts`: Remove the sleep workaround (no longer needed)

## Test plan
- [x] `pnpm --filter durably test:node` passes (186 tests)
- [x] Ran target test 5 times consecutively with no failures

Fixes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)