### PR TITLE
perf: optimize step boundary cancellation check

### DIFF
--- a/packages/durably/src/context.ts
+++ b/packages/durably/src/context.ts
@@ -32,10 +32,21 @@ export function createStepContext(
       name: string,
       fn: (signal: AbortSignal) => T | Promise<T>,
     ): Promise<T> {
-      // Check if run was cancelled before executing this step
+      // Fast path: check in-memory signal first (set by run:cancel event)
+      if (controller.signal.aborted) {
+        throw new CancelledError(run.id)
+      }
+
+      // Slow path: DB check for cases where event wasn't received
+      // (e.g., run cancelled while worker was down, then resumed)
       const currentRun = await storage.getRun(run.id)
       if (currentRun?.status === 'cancelled') {
         controller.abort()
+        throw new CancelledError(run.id)
+      }
+
+      // Check cancellation before replaying cached steps
+      if (controller.signal.aborted) {
         throw new CancelledError(run.id)
       }
 


### PR DESCRIPTION
## Summary
- Check `controller.signal.aborted` (in-memory) before `storage.getRun()` (DB query) at step boundaries
- When cancellation is detected via the `run:cancel` event, the DB query is skipped entirely
- Also adds signal check before replaying cached steps during resume, improving cancellation responsiveness for jobs with many completed steps
- DB fallback is preserved for edge cases (e.g., run cancelled while worker was down)

## Changes
- `packages/durably/src/context.ts`: Add fast-path signal checks before DB queries

## Test plan
- [x] `pnpm --filter durably test:node` passes (186 tests)
- [x] Existing cancellation tests cover both signal-based and DB-based cancellation paths

Fixes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)