### PR TITLE
refactor: consolidate migrations v1-v3 into single v1

### DIFF
--- a/packages/durably/src/migrations.ts
+++ b/packages/durably/src/migrations.ts
@@ -9,7 +9,7 @@ interface Migration {
   up: (db: Kysely<Database>) => Promise<void>
 }
 
-export const LATEST_SCHEMA_VERSION = 3
+export const LATEST_SCHEMA_VERSION = 1
 
 const migrations: Migration[] = [
   {
@@ -21,10 +21,11 @@ const migrations: Migration[] = [
         .ifNotExists()
         .addColumn('id', 'text', (col) => col.primaryKey())
         .addColumn('job_name', 'text', (col) => col.notNull())
-        .addColumn('payload', 'text', (col) => col.notNull())
+        .addColumn('input', 'text', (col) => col.notNull())
         .addColumn('status', 'text', (col) => col.notNull())
         .addColumn('idempotency_key', 'text')
         .addColumn('concurrency_key', 'text')
+        .addColumn('labels', 'text', (col) => col.notNull().defaultTo('{}'))
         .addColumn('current_step_index', 'integer', (col) =>
           col.notNull().defaultTo(0),
         )
@@ -32,6 +33,8 @@ const migrations: Migration[] = [
         .addColumn('output', 'text')
         .addColumn('error', 'text')
         .addColumn('heartbeat_at', 'text', (col) => col.notNull())
+        .addColumn('started_at', 'text')
+        .addColumn('completed_at', 'text')
         .addColumn('created_at', 'text', (col) => col.notNull())
         .addColumn('updated_at', 'text', (col) => col.notNull())
         .execute()
@@ -112,37 +115,6 @@ const migrations: Migration[] = [
         .execute()
     },
   },
-  {
-    version: 2,
-    up: async (db) => {
-      // Add labels column to runs table
-      await db.schema
-        .alterTable('durably_runs')
-        .addColumn('labels', 'text', (col) => col.notNull().defaultTo('{}'))
-        .execute()
-    },
-  },
-  {
-    version: 3,
-    up: async (db) => {
-      // Rename payload column to input
-      await db.schema
-        .alterTable('durably_runs')
-        .renameColumn('payload', 'input')
-        .execute()
-
-      // Add started_at and completed_at columns
-      await db.schema
-        .alterTable('durably_runs')
-        .addColumn('started_at', 'text')
-        .execute()
-
-      await db.schema
-        .alterTable('durably_runs')
-        .addColumn('completed_at', 'text')
-        .execute()
-    },
-  },
 ]
 
 /**
@@ -172,15 +144,17 @@ export async function runMigrations(db: Kysely<Database>): Promise<void> {
 
   for (const migration of migrations) {
     if (migration.version > currentVersion) {
-      await migration.up(db)
+      await db.transaction().execute(async (trx) => {
+        await migration.up(trx)
 
-      await db
-        .insertInto('durably_schema_versions')
-        .values({
-          version: migration.version,
-          applied_at: new Date().toISOString(),
-        })
-        .execute()
+        await trx
+          .insertInto('durably_schema_versions')
+          .values({
+            version: migration.version,
+            applied_at: new Date().toISOString(),
+          })
+          .execute()
+      })
     }
   }
 }

--- a/packages/durably/tests/shared/migrate.shared.ts
+++ b/packages/durably/tests/shared/migrate.shared.ts
@@ -68,7 +68,7 @@ export function createMigrateTests(createDialect: () => Dialect) {
       `.execute(durably.db)
 
       expect(result.rows).toHaveLength(1)
-      expect(result.rows[0].version).toBe(3)
+      expect(result.rows[0].version).toBe(1)
     })
 
     it('is idempotent (can be called multiple times safely)', async () => {
@@ -83,7 +83,7 @@ export function createMigrateTests(createDialect: () => Dialect) {
       `.execute(durably.db)
 
       // Should have version records for each migration
-      expect(result.rows).toHaveLength(3)
+      expect(result.rows).toHaveLength(1)
     })
   })
 }


### PR DESCRIPTION
## Summary
- Merged v1, v2, v3 migrations into a single v1 that creates the final schema directly
- No more ALTER TABLEs — `input`, `labels`, `started_at`, `completed_at` are all in the initial CREATE TABLE
- Eliminates #43 atomicity issue entirely (no multi-step DDL that can partially fail)

## Breaking Change
Existing databases need to be recreated (`durably.migrate()` on a fresh DB). This is acceptable since the library is pre-1.0 and v3 already broke backward compatibility.

## Test plan
- [x] `pnpm validate` passes (all 135 tests, lint, typecheck, format)

🤖 Generated with [Claude Code](https://claude.com/claude-code)