### PR TITLE
docs: fix inaccuracies in API docs and guides

### DIFF
--- a/website/api/durably-react/browser.md
+++ b/website/api/durably-react/browser.md
@@ -102,7 +102,6 @@ const myJob = defineJob({
 
 function Component() {
   const {
-    isReady,
     trigger,
     triggerAndWait,
     status,
@@ -126,7 +125,7 @@ function Component() {
 
   return (
     <div>
-      <button onClick={handleClick} disabled={!isReady || isRunning}>
+      <button onClick={handleClick} disabled={isRunning}>
         Run
       </button>
       <p>Status: {status}</p>
@@ -153,7 +152,6 @@ function Component() {
 
 ```ts
 interface UseJobResult<TInput, TOutput> {
-  isReady: boolean
   trigger: (input: TInput) => Promise<{ runId: string }>
   triggerAndWait: (input: TInput) => Promise<{ runId: string; output: TOutput }>
   status: RunStatus | null
@@ -182,7 +180,6 @@ import { useJobRun } from '@coji/durably-react'
 
 function RunMonitor({ runId }: { runId: string | null }) {
   const {
-    isReady,
     status,
     output,
     error,
@@ -221,7 +218,7 @@ Subscribe to logs from a run.
 import { useJobLogs } from '@coji/durably-react'
 
 function LogViewer({ runId }: { runId: string | null }) {
-  const { isReady, logs, clearLogs } = useJobLogs({
+  const { logs, clearLogs } = useJobLogs({
     runId,
     maxLogs: 100,
   })

--- a/website/api/index.md
+++ b/website/api/index.md
@@ -219,11 +219,11 @@ function ImportButton() {
 
 ### Step Context
 
-| Method                               | Description                                                                               |
-| ------------------------------------ | ----------------------------------------------------------------------------------------- |
-| `step.run(name, fn)`                 | Create resumable checkpoint. `fn` receives an `AbortSignal` for cooperative cancellation. |
-| `step.progress(current, total, msg)` | Report progress                                                                           |
-| `step.log.info/warn/error(msg)`      | Write structured logs                                                                     |
+| Method                                 | Description                                                                               |
+| -------------------------------------- | ----------------------------------------------------------------------------------------- |
+| `step.run(name, fn)`                   | Create resumable checkpoint. `fn` receives an `AbortSignal` for cooperative cancellation. |
+| `step.progress(current, total?, msg?)` | Report progress                                                                           |
+| `step.log.info/warn/error(msg)`        | Write structured logs                                                                     |
 
 ### React Hooks (@coji/durably-react)
 

--- a/website/api/step.md
+++ b/website/api/step.md
@@ -83,14 +83,14 @@ step.log.error('Failed to fetch', { error: err.message })
 Reports progress for the current run.
 
 ```ts
-step.progress(current: number, total: number, message?: string): void
+step.progress(current: number, total?: number, message?: string): void
 ```
 
-| Parameter | Type     | Description               |
-| --------- | -------- | ------------------------- |
-| `current` | `number` | Current progress value    |
-| `total`   | `number` | Total progress value      |
-| `message` | `string` | Optional progress message |
+| Parameter | Type     | Description                     |
+| --------- | -------- | ------------------------------- |
+| `current` | `number` | Current progress value          |
+| `total`   | `number` | Total progress value (optional) |
+| `message` | `string` | Optional progress message       |
 
 ```ts
 step.progress(0, 100, 'Starting...')

--- a/website/guide/background-sync.md
+++ b/website/guide/background-sync.md
@@ -146,6 +146,10 @@ durably.on('step:cancel', (event) => {
   console.log(`[step:cancel] ${event.stepName}`)
 })
 
+durably.on('step:fail', (event) => {
+  console.log(`[step:fail] ${event.stepName}: ${event.error}`)
+})
+
 durably.on('run:complete', (event) => {
   console.log(
     `[run:complete] output=${JSON.stringify(event.output)} duration=${event.duration}ms`,

--- a/website/guide/concepts.md
+++ b/website/guide/concepts.md
@@ -192,10 +192,12 @@ GET /runs/subscribe?label.organizationId=org_123
 Monitor job execution:
 
 ```ts
+durably.on('run:trigger', ({ runId, jobName }) => { ... })
 durably.on('run:start', ({ runId, jobName }) => { ... })
 durably.on('run:progress', ({ runId, progress }) => { ... })
 durably.on('run:complete', ({ runId, output }) => { ... })
 durably.on('run:fail', ({ runId, error }) => { ... })
+durably.on('run:cancel', ({ runId, jobName }) => { ... })
 durably.on('step:start', ({ runId, stepName }) => { ... })
 durably.on('step:complete', ({ runId, stepName, output }) => { ... })
 durably.on('step:fail', ({ runId, stepName, error }) => { ... })


### PR DESCRIPTION
## Summary
- Fix `step.progress()` `total` parameter documented as required but actually optional (closes #50)
- Remove non-existent `isReady` from `useJob`/`useJobRun`/`useJobLogs` return type docs (closes #51)
- Add `step:fail` event listener to background-sync guide (closes #52)
- Add `run:trigger` and `run:cancel` to concepts.md events section (closes #53)

## Test plan
- [x] `pnpm validate` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new event listeners enabling real-time monitoring of step failures, job run triggers, and run cancellations for enhanced event tracking.

* **Documentation**
  * Simplified API interfaces with streamlined return types and optional parameters for improved usability.
  * Updated guides with comprehensive event monitoring examples and capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->