### PR TITLE
docs: clarify createDurablyClient is not compatible with SSR

### DIFF
--- a/packages/durably-react/docs/llms.md
+++ b/packages/durably-react/docs/llms.md
@@ -321,7 +321,9 @@ Import from `@coji/durably-react/client` for server-connected mode.
 
 ### createDurablyClient
 
-Create a type-safe client for all registered jobs (recommended):
+Create a type-safe client for all registered jobs (recommended).
+
+**Not compatible with SSR** (e.g., React Router with `ssr: true`). The Proxy object loses its trap through Vite's SSR module loader. For SSR apps, use `useJob`/`useRuns` hooks directly with the `api` option.
 
 ```tsx
 // Server: register jobs (app/lib/durably.server.ts)

--- a/website/api/durably-react/client.md
+++ b/website/api/durably-react/client.md
@@ -17,6 +17,9 @@ import {
 
 Create a type-safe client for all registered jobs. This is the recommended way to use server-connected mode.
 
+> [!WARNING]
+> `createDurablyClient` is **not compatible with SSR** (e.g., React Router with `ssr: true`). It returns a `Proxy` object that loses its trap when processed through Vite's SSR module loader. For SSR apps, use `useJob` and `useRuns` hooks directly with the `api` option instead. See the [fullstack-react-router example](https://github.com/coji/durably/tree/main/examples/fullstack-react-router) for the correct pattern.
+
 ### Server Setup
 
 ```ts

--- a/website/public/llms.txt
+++ b/website/public/llms.txt
@@ -821,7 +821,9 @@ Import from `@coji/durably-react/client` for server-connected mode.
 
 ### createDurablyClient
 
-Create a type-safe client for all registered jobs (recommended):
+Create a type-safe client for all registered jobs (recommended).
+
+**Not compatible with SSR** (e.g., React Router with `ssr: true`). The Proxy object loses its trap through Vite's SSR module loader. For SSR apps, use `useJob`/`useRuns` hooks directly with the `api` option.
 
 ```tsx
 // Server: register jobs (app/lib/durably.server.ts)


### PR DESCRIPTION
## Summary
- Add SSR incompatibility warning to `createDurablyClient` docs (closes #24)
- Updated in both website API reference and package llms.md
- Points SSR users to use `useJob`/`useRuns` hooks directly with `api` option

## Test plan
- [x] `pnpm validate` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)