### PR TITLE
docs: update docs for TriggerAndWaitOptions, ProgressData, LogData

### DIFF
--- a/packages/durably/docs/llms.md
+++ b/packages/durably/docs/llms.md
@@ -470,7 +470,7 @@ interface JobHandle<TName, TInput, TOutput> {
   trigger(input: TInput, options?: TriggerOptions): Promise<Run<TOutput>>
   triggerAndWait(
     input: TInput,
-    options?: TriggerOptions,
+    options?: TriggerAndWaitOptions,
   ): Promise<{ id: string; output: TOutput }>
   batchTrigger(inputs: BatchTriggerInput<TInput>[]): Promise<Run<TOutput>[]>
   getRun(id: string): Promise<Run<TOutput> | null>
@@ -481,7 +481,25 @@ interface TriggerOptions {
   idempotencyKey?: string
   concurrencyKey?: string
   labels?: Record<string, string>
+}
+
+interface TriggerAndWaitOptions extends TriggerOptions {
   timeout?: number
+  onProgress?: (progress: ProgressData) => void | Promise<void>
+  onLog?: (log: LogData) => void | Promise<void>
+}
+
+interface ProgressData {
+  current: number
+  total?: number
+  message?: string
+}
+
+interface LogData {
+  level: 'info' | 'warn' | 'error'
+  message: string
+  data?: unknown
+  stepName?: string | null
 }
 
 interface RunFilter {

--- a/website/api/events.md
+++ b/website/api/events.md
@@ -313,7 +313,25 @@ type DurablyEvent =
   | StepCancelEvent
   | LogWriteEvent
   | WorkerErrorEvent
+
+// Shared data types used by events and callbacks
+interface ProgressData {
+  current: number
+  total?: number
+  message?: string
+}
+
+interface LogData {
+  level: 'info' | 'warn' | 'error'
+  message: string
+  data?: unknown
+  stepName?: string | null
+}
 ```
+
+`RunProgressEvent` contains a `progress: ProgressData` field. `LogWriteEvent` extends `LogData` with additional event fields (`runId`, `jobName`, `labels`, etc.).
+
+Both `ProgressData` and `LogData` are also used as callback parameter types in [`TriggerAndWaitOptions`](/api/create-durably#triggerandwait).
 
 ## Example
 

--- a/website/api/index.md
+++ b/website/api/index.md
@@ -248,6 +248,9 @@ import type {
   Run,
   RunStatus,
   TriggerOptions,
+  TriggerAndWaitOptions,
+  ProgressData,
+  LogData,
   DurablyEvent,
   EventType,
 } from '@coji/durably'

--- a/website/public/llms.txt
+++ b/website/public/llms.txt
@@ -470,7 +470,7 @@ interface JobHandle<TName, TInput, TOutput> {
   trigger(input: TInput, options?: TriggerOptions): Promise<Run<TOutput>>
   triggerAndWait(
     input: TInput,
-    options?: TriggerOptions,
+    options?: TriggerAndWaitOptions,
   ): Promise<{ id: string; output: TOutput }>
   batchTrigger(inputs: BatchTriggerInput<TInput>[]): Promise<Run<TOutput>[]>
   getRun(id: string): Promise<Run<TOutput> | null>
@@ -481,7 +481,25 @@ interface TriggerOptions {
   idempotencyKey?: string
   concurrencyKey?: string
   labels?: Record<string, string>
+}
+
+interface TriggerAndWaitOptions extends TriggerOptions {
   timeout?: number
+  onProgress?: (progress: ProgressData) => void | Promise<void>
+  onLog?: (log: LogData) => void | Promise<void>
+}
+
+interface ProgressData {
+  current: number
+  total?: number
+  message?: string
+}
+
+interface LogData {
+  level: 'info' | 'warn' | 'error'
+  message: string
+  data?: unknown
+  stepName?: string | null
 }
 
 interface RunFilter {


### PR DESCRIPTION
## Summary

Update documentation to reflect API changes from PR #71:

- `TriggerOptions` split into `TriggerOptions` + `TriggerAndWaitOptions`
- New exported types: `ProgressData`, `LogData`, `TriggerAndWaitOptions`
- `LogWriteEvent` now extends `LogData`

### Files updated

- `packages/durably/docs/llms.md` — Core LLM docs
- `website/api/index.md` — Type exports cheat sheet
- `website/api/events.md` — Event type definitions
- `website/public/llms.txt` — Regenerated

🤖 Generated with [Claude Code](https://claude.com/claude-code)