### PR TITLE
refactor: extract getRunOrThrow and executeAction helpers

### DIFF
--- a/packages/durably-react/src/client/use-run-actions.ts
+++ b/packages/durably-react/src/client/use-run-actions.ts
@@ -130,7 +130,9 @@ export function useRunActions(
         { method: 'POST' },
       )
       if (!data.runId) {
-        throw new Error('Failed to retrigger: missing runId in response')
+        const message = 'Failed to retrigger: missing runId in response'
+        setError(message)
+        throw new Error(message)
       }
       return data.runId
     },

--- a/packages/durably/src/durably.ts
+++ b/packages/durably/src/durably.ts
@@ -283,12 +283,12 @@ function createDurablyInstance<
 >(state: DurablyState, jobs: TJobs): Durably<TJobs, TLabels> {
   const { db, storage, eventEmitter, jobRegistry, worker } = state
 
-  async function getRunOrThrow(runId: string): Promise<Run> {
+  async function getRunOrThrow(runId: string): Promise<Run<TLabels>> {
     const run = await storage.getRun(runId)
     if (!run) {
       throw new Error(`Run not found: ${runId}`)
     }
-    return run
+    return run as Run<TLabels>
   }
 
   const durably: Durably<TJobs, TLabels> = {


### PR DESCRIPTION
## Summary

- Extract `getRunOrThrow()` helper in `durably.ts` — deduplicates the `getRun` + null check + throw pattern used in `retrigger()`, `cancel()`, and `deleteRun()` (#90)
- Extract `executeAction()` helper in `useRunActions.ts` — deduplicates the fetch + error handling + loading state boilerplate across `retrigger`, `cancel`, `deleteRun`, and `getSteps` (#89)
- Net reduction: **-108 / +56 lines**

Closes #90
Closes #89

## Test plan

- [x] `pnpm validate` passes (all 145 tests, format, lint, typecheck)
- No behavior changes — pure refactor

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal error handling consistency across action operations.
  * Streamlined request and loading state management for better code maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->