### PR TITLE
docs: add PostgreSQL example

### DIFF
--- a/examples/server-node-postgres/basic.ts
+++ b/examples/server-node-postgres/basic.ts
@@ -1,0 +1,58 @@
+/**
+ * Node.js + PostgreSQL Example for Durably
+ *
+ * This example shows basic usage of Durably with PostgreSQL.
+ * Run: DATABASE_URL=postgresql://localhost:5432/durably tsx basic.ts
+ */
+
+import { durably } from './lib/durably'
+
+// Subscribe to events
+durably.on('run:leased', (event) => {
+  console.log(`[run:leased] ${event.jobName}`)
+})
+
+durably.on('step:complete', (event) => {
+  console.log(`[step:complete] ${event.stepName}`)
+})
+
+durably.on('run:complete', (event) => {
+  console.log(
+    `[run:complete] output=${JSON.stringify(event.output)} duration=${event.duration}ms`,
+  )
+})
+
+durably.on('run:fail', (event) => {
+  console.log(`[run:fail] ${event.error}`)
+})
+
+// Main
+async function main() {
+  console.log('Durably Node.js + PostgreSQL Example')
+  console.log('====================================\n')
+
+  await durably.init()
+  console.log('Initialized\n')
+
+  // Trigger job and wait for completion
+  const { id, output } = await durably.jobs.processImage.triggerAndWait({
+    filename: 'photo.jpg',
+  })
+  console.log(`\nRun ${id} completed`)
+  console.log(`Output: ${JSON.stringify(output)}`)
+
+  // Show stats
+  const runs = await durably.getRuns()
+  console.log(`\nDatabase Stats:`)
+  console.log(
+    `  Completed: ${runs.filter((r) => r.status === 'completed').length}`,
+  )
+  console.log(`  Failed: ${runs.filter((r) => r.status === 'failed').length}`)
+
+  // Cleanup
+  await durably.stop()
+  await durably.db.destroy()
+  console.log('\nDone!')
+}
+
+main().catch(console.error)

--- a/examples/server-node-postgres/biome.json
+++ b/examples/server-node-postgres/biome.json
@@ -1,0 +1,5 @@
+{
+  "root": false,
+  "$schema": "https://biomejs.dev/schemas/2.4.6/schema.json",
+  "extends": ["../../biome.json"]
+}

--- a/examples/server-node-postgres/jobs/index.ts
+++ b/examples/server-node-postgres/jobs/index.ts
@@ -1,0 +1,1 @@
+export { processImageJob } from './process-image'

--- a/examples/server-node-postgres/jobs/process-image.ts
+++ b/examples/server-node-postgres/jobs/process-image.ts
@@ -1,0 +1,34 @@
+/**
+ * Process Image Job
+ *
+ * Simulates image processing with multiple steps.
+ */
+
+import { defineJob } from '@coji/durably'
+import { z } from 'zod'
+
+const delay = (ms: number) => new Promise((r) => setTimeout(r, ms))
+
+export const processImageJob = defineJob({
+  name: 'process-image',
+  input: z.object({ filename: z.string() }),
+  output: z.object({ url: z.string() }),
+  run: async (step, input) => {
+    const data = await step.run('download', async () => {
+      await delay(500)
+      return { size: 1024000 }
+    })
+
+    await step.run('resize', async () => {
+      await delay(500)
+      return { width: 800, height: 600, size: data.size / 2 }
+    })
+
+    const uploaded = await step.run('upload', async () => {
+      await delay(500)
+      return { url: `https://cdn.example.com/${input.filename}` }
+    })
+
+    return { url: uploaded.url }
+  },
+})

--- a/examples/server-node-postgres/lib/database.ts
+++ b/examples/server-node-postgres/lib/database.ts
@@ -1,0 +1,16 @@
+/**
+ * Database Configuration
+ *
+ * PostgreSQL dialect for multi-worker deployments.
+ * Set DATABASE_URL environment variable to connect.
+ */
+
+import { PostgresDialect } from 'kysely'
+import pg from 'pg'
+
+export const dialect = new PostgresDialect({
+  pool: new pg.Pool({
+    connectionString:
+      process.env.DATABASE_URL ?? 'postgresql://localhost:5432/durably',
+  }),
+})

--- a/examples/server-node-postgres/lib/durably.ts
+++ b/examples/server-node-postgres/lib/durably.ts
@@ -1,0 +1,20 @@
+/**
+ * Durably Server Configuration
+ *
+ * Sets up Durably instance with PostgreSQL and registers jobs.
+ */
+
+import { createDurably } from '@coji/durably'
+import { processImageJob } from '../jobs'
+import { dialect } from './database'
+
+export const durably = createDurably({
+  dialect,
+  pollingIntervalMs: 1000,
+  leaseRenewIntervalMs: 5000,
+  leaseMs: 30000,
+  retainRuns: '7d',
+  jobs: {
+    processImage: processImageJob,
+  },
+})

--- a/examples/server-node-postgres/package.json
+++ b/examples/server-node-postgres/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "example-server-node-postgres",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "tsx basic.ts",
+    "typecheck": "tsc --noEmit",
+    "lint": "biome lint .",
+    "lint:fix": "biome lint --write .",
+    "format": "prettier --experimental-cli --check .",
+    "format:fix": "prettier --experimental-cli --write ."
+  },
+  "dependencies": {
+    "@coji/durably": "workspace:*",
+    "kysely": "^0.28.12",
+    "pg": "^8.16.3",
+    "zod": "^4.3.6"
+  },
+  "devDependencies": {
+    "@biomejs/biome": "^2.4.7",
+    "@types/node": "^25.5.0",
+    "@types/pg": "^8.15.6",
+    "prettier": "^3.8.1",
+    "prettier-plugin-organize-imports": "^4.3.0",
+    "tsx": "^4.21.0",
+    "typescript": "^5.9.3"
+  }
+}

--- a/examples/server-node-postgres/prettier.config.js
+++ b/examples/server-node-postgres/prettier.config.js
@@ -1,0 +1,7 @@
+export default {
+  semi: false,
+  singleQuote: true,
+  trailingComma: 'all',
+  printWidth: 80,
+  plugins: ['prettier-plugin-organize-imports'],
+}

--- a/examples/server-node-postgres/tsconfig.json
+++ b/examples/server-node-postgres/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "noEmit": true
+  },
+  "include": ["*.ts", "lib/**/*.ts", "jobs/**/*.ts"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -213,6 +213,43 @@ importers:
         specifier: ^5.9.3
         version: 5.9.3
 
+  examples/server-node-postgres:
+    dependencies:
+      '@coji/durably':
+        specifier: workspace:*
+        version: link:../../packages/durably
+      kysely:
+        specifier: ^0.28.12
+        version: 0.28.12
+      pg:
+        specifier: ^8.16.3
+        version: 8.20.0
+      zod:
+        specifier: ^4.3.6
+        version: 4.3.6
+    devDependencies:
+      '@biomejs/biome':
+        specifier: ^2.4.7
+        version: 2.4.7
+      '@types/node':
+        specifier: ^25.5.0
+        version: 25.5.0
+      '@types/pg':
+        specifier: ^8.15.6
+        version: 8.18.0
+      prettier:
+        specifier: ^3.8.1
+        version: 3.8.1
+      prettier-plugin-organize-imports:
+        specifier: ^4.3.0
+        version: 4.3.0(prettier@3.8.1)(typescript@5.9.3)
+      tsx:
+        specifier: ^4.21.0
+        version: 4.21.0
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+
   examples/spa-react-router:
     dependencies:
       '@coji/durably':


### PR DESCRIPTION
## Summary
- New example: `examples/server-node-postgres/` — Node.js + PostgreSQL variant of server-node
- Uses `PostgresDialect` from kysely with `pg.Pool`
- Demonstrates `retainRuns: '7d'` for auto-cleanup
- Same job structure as server-node for easy comparison

Closes #111

## Test plan
- [x] `pnpm validate` passes (28/28 tasks including new example)

🤖 Generated with [Claude Code](https://claude.com/claude-code)