### PR TITLE
perf: skip write mutex for PostgreSQL backend

### DIFF
--- a/packages/durably/src/storage.ts
+++ b/packages/durably/src/storage.ts
@@ -1045,33 +1045,38 @@ export function createKyselyStore(
     },
   }
 
-  // Wrap all mutating methods with write lock to prevent SQLITE_BUSY.
-  // libsql opens separate connections for transactions, so concurrent
-  // writes from the same Kysely instance can conflict. The mutex
-  // serializes writes within a single process. Reads are not locked.
-  const mutatingKeys = [
-    'enqueue',
-    'enqueueMany',
-    'updateRun',
-    'deleteRun',
-    'purgeRuns',
-    'claimNext',
-    'renewLease',
-    'releaseExpiredLeases',
-    'completeRun',
-    'failRun',
-    'cancelRun',
-    'persistStep',
-    'deleteSteps',
-    'updateProgress',
-    'createLog',
-  ] as const
+  // SQLite/libsql: wrap mutating methods with write lock to prevent SQLITE_BUSY.
+  // libsql opens separate connections for transactions, so concurrent writes
+  // from the same Kysely instance can conflict. The mutex serializes writes
+  // within a single process. Reads are not locked.
+  //
+  // PostgreSQL: skip the mutex entirely. PostgreSQL handles concurrent writes
+  // natively via MVCC, advisory locks, and FOR UPDATE SKIP LOCKED.
+  if (backend !== 'postgres') {
+    const mutatingKeys = [
+      'enqueue',
+      'enqueueMany',
+      'updateRun',
+      'deleteRun',
+      'purgeRuns',
+      'claimNext',
+      'renewLease',
+      'releaseExpiredLeases',
+      'completeRun',
+      'failRun',
+      'cancelRun',
+      'persistStep',
+      'deleteSteps',
+      'updateProgress',
+      'createLog',
+    ] as const
 
-  for (const key of mutatingKeys) {
-    const original = store[key] as (...args: unknown[]) => Promise<unknown>
-    ;(store as unknown as Record<string, unknown>)[key] = (
-      ...args: unknown[]
-    ): Promise<unknown> => withWriteLock(() => original.apply(store, args))
+    for (const key of mutatingKeys) {
+      const original = store[key] as (...args: unknown[]) => Promise<unknown>
+      ;(store as unknown as Record<string, unknown>)[key] = (
+        ...args: unknown[]
+      ): Promise<unknown> => withWriteLock(() => original.apply(store, args))
+    }
   }
 
   return store


### PR DESCRIPTION
## Summary

The write mutex that serializes all mutating operations was unconditionally applied to all backends, including PostgreSQL. This defeated PostgreSQL's native concurrent write capabilities (MVCC, advisory locks, FOR UPDATE SKIP LOCKED).

Now the mutex is only applied when `backend !== 'postgres'`.

## Why this is safe

- **SQLite/libsql**: Needs the mutex. libsql opens separate connections for transactions, causing SQLITE_BUSY conflicts without serialization.
- **PostgreSQL**: Doesn't need it. Concurrent transactions are handled by the database itself. The `claimNext` implementation already uses `FOR UPDATE SKIP LOCKED` + `pg_advisory_xact_lock` for safe concurrent claiming.

## Test results

- SQLite tests: 161 passed (mutex still active)
- PostgreSQL tests: 11 passed (mutex bypassed)
- Browser tests: all passed

Closes #123

🤖 Generated with [Claude Code](https://claude.com/claude-code)