### PR TITLE
docs: RFC for coalesce trigger + concurrencyKey pending limit (#143)

### DIFF
--- a/docs/rfcs/coalesce-trigger/README.md
+++ b/docs/rfcs/coalesce-trigger/README.md
@@ -2,6 +2,8 @@
 
 Issue: #143
 
+> **Note**: Pseudo-code in this RFC is illustrative. The 28 test cases define the contract; implementation details will be validated by tests.
+
 ## Problem
 
 Webhook-driven workloads can trigger many jobs in rapid succession for the same logical entity. Since the job reads latest state from DB at execution time, intermediate triggers are redundant. Without coalescing, N webhook events create N queued runs — all executing sequentially but wastefully.


### PR DESCRIPTION
## Summary

trigger() に coalesce オプションを追加する RFC。2つの breaking change を含む (pre-v1):

### 1. concurrencyKey が max 1 pending を強制
- Partial unique index で DB レベルで保証
- coalesce なしで 2個目の pending → `ConflictError`
- `coalesce: 'skip'` で graceful に既存 pending を返す

### 2. trigger() が `TriggerResult` を返す
- `TypedRun & { disposition }` — destructure 不要
- `disposition: 'created' | 'idempotent' | 'coalesced'`
- 既存の Run プロパティアクセスはそのまま動く

### その他
- `coalesce: 'skip'` (string union, 将来の拡張に対応)
- `run:coalesced` イベント (observability)
- INSERT-first, catch conflict パターン (TOCTOU race なし)
- Fail-fast migration (既存の重複 pending データがあればエラー)

### レビュー経緯
- Claude Code → 初版 RFC
- Codex (GPT) → PostgreSQL race 指摘、disposition モデル提案
- upflow 開発者 → breaking change 推奨、disposition の実用性確認
- Codex (GPT) → partial unique index の既存挙動衝突を指摘
- 最終判断: 正面突破で全 breaking change を受け入れ

Ref #143

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * トリガー動作と並行制御に関する新しいRFCを追加しました。jobごとに「保留実行は最大1件」を保証するconcurrencyKey、衝突時のConflict動作とオプトインのcoalesce（既存実行を返す）モード、triggerの戻り値に含まれる処理結果(disposition: created|idempotent|coalesced)、イベント発行ルールの変更、期限切れリースの二相解放による修正、バッチ処理動作および移行手順を詳述しています。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->