### PR TITLE
docs: fill durably-react API reference gaps

### DIFF
--- a/packages/durably-react/docs/llms.md
+++ b/packages/durably-react/docs/llms.md
@@ -573,6 +573,8 @@ function FilteredDashboard() {
 }
 ```
 
+Return type: `{ runs, page, hasMore, isLoading, nextPage, prevPage, goToPage, refresh }`. Pagination is 0-indexed. Filter semantics: `status` array matches any, `labels` must all match.
+
 ## Server Handler Setup
 
 On your server, use `createDurablyHandler`:

--- a/website/api/durably-react/fullstack.md
+++ b/website/api/durably-react/fullstack.md
@@ -27,10 +27,23 @@ export const durably = createDurably({
   },
 })
 
-export const durablyHandler = createDurablyHandler(durably)
+export const durablyHandler = createDurablyHandler(durably, {
+  sseThrottleMs: 100, // throttle SSE progress events (default: 100ms, 0 to disable)
+  onRequest: async () => {
+    // called before handling each request (after authentication)
+  },
+})
 
 await durably.init()
 ```
+
+### createDurablyHandler Options
+
+| Option          | Type                          | Description                                                              |
+| --------------- | ----------------------------- | ------------------------------------------------------------------------ |
+| `sseThrottleMs` | `number`                      | Throttle interval for SSE progress events (default: 100ms, 0 to disable) |
+| `onRequest`     | `() => Promise<void> \| void` | Called before handling each request (after authentication)               |
+| `auth`          | `AuthConfig`                  | Auth middleware configuration (see [Auth guide](/guide/auth))            |
 
 ```ts
 // app/routes/api.durably.$.ts
@@ -392,8 +405,8 @@ useRuns(options)
 | ---------- | -------------------------- | ------------------------------------------------------ |
 | `api`      | `string`                   | API base path                                          |
 | `jobName`  | `string \| string[]`       | Filter by job name(s) (only for untyped usage)         |
-| `status`   | `RunStatus \| RunStatus[]` | Filter by status(es)                                   |
-| `labels`   | `Record<string, string>`   | Filter by labels                                       |
+| `status`   | `RunStatus \| RunStatus[]` | Filter by status(es) — array matches any               |
+| `labels`   | `Record<string, string>`   | Filter by labels — all specified labels must match     |
 | `pageSize` | `number`                   | Number of runs per page                                |
 | `realtime` | `boolean`                  | Subscribe to SSE updates on first page (default: true) |
 

--- a/website/api/durably-react/spa.md
+++ b/website/api/durably-react/spa.md
@@ -209,6 +209,21 @@ function RunMonitor({ runId }: { runId: string | null }) {
 | ------- | ---------------- | -------------------------- |
 | `runId` | `string \| null` | The run ID to subscribe to |
 
+### Return Type
+
+| Property      | Type                | Description                     |
+| ------------- | ------------------- | ------------------------------- |
+| `status`      | `RunStatus \| null` | Current run status              |
+| `output`      | `TOutput \| null`   | Output from completed run       |
+| `error`       | `string \| null`    | Error message from failed run   |
+| `logs`        | `LogEntry[]`        | Logs collected during execution |
+| `progress`    | `Progress \| null`  | Current progress                |
+| `isLeased`    | `boolean`           | Whether the run is executing    |
+| `isPending`   | `boolean`           | Whether the run is queued       |
+| `isCompleted` | `boolean`           | Whether the run completed       |
+| `isFailed`    | `boolean`           | Whether the run failed          |
+| `isCancelled` | `boolean`           | Whether the run was cancelled   |
+
 ---
 
 ## useJobLogs
@@ -357,13 +372,13 @@ useRuns(options?)
 
 ### Options
 
-| Option     | Type                       | Description                                    |
-| ---------- | -------------------------- | ---------------------------------------------- |
-| `jobName`  | `string \| string[]`       | Filter by job name(s) (only for untyped usage) |
-| `status`   | `RunStatus \| RunStatus[]` | Filter by status(es)                           |
-| `labels`   | `Record<string, string>`   | Filter by labels                               |
-| `pageSize` | `number`                   | Number of runs per page (default: 10)          |
-| `realtime` | `boolean`                  | Subscribe to real-time updates (default: true) |
+| Option     | Type                       | Description                                        |
+| ---------- | -------------------------- | -------------------------------------------------- |
+| `jobName`  | `string \| string[]`       | Filter by job name(s) (only for untyped usage)     |
+| `status`   | `RunStatus \| RunStatus[]` | Filter by status(es) — array matches any           |
+| `labels`   | `Record<string, string>`   | Filter by labels — all specified labels must match |
+| `pageSize` | `number`                   | Number of runs per page (default: 10)              |
+| `realtime` | `boolean`                  | Subscribe to real-time updates (default: true)     |
 
 ### Return Type
 

--- a/website/api/durably-react/types.md
+++ b/website/api/durably-react/types.md
@@ -94,6 +94,108 @@ interface ClientRun {
 | `completedAt`        | `string \| null`         | ISO timestamp of completion     |
 | `createdAt`          | `string`                 | ISO timestamp of creation       |
 
+## TypedClientRun
+
+A typed version of `ClientRun` with generic input/output types. Used by fullstack hooks (HTTP/SSE connection).
+
+```ts
+type TypedClientRun<
+  TInput extends Record<string, unknown> = Record<string, unknown>,
+  TOutput extends Record<string, unknown> | undefined = Record<string, unknown>,
+> = Omit<ClientRun, 'input' | 'output'> & {
+  input: TInput
+  output: TOutput | null
+}
+```
+
+Use with `useRuns` to get typed runs in a multi-job dashboard:
+
+```tsx
+type ImportRun = TypedClientRun<{ file: string }, { count: number }>
+type SyncRun = TypedClientRun<{ userId: string }, { synced: boolean }>
+type DashboardRun = ImportRun | SyncRun
+
+const { runs } = durably.useRuns<DashboardRun>({ pageSize: 10 })
+```
+
+## TypedRun
+
+A typed version of the core `Run` type with generic input/output types. Used by SPA hooks (direct Durably access). Same shape as `TypedClientRun` but based on the full `Run` type (includes internal fields like `leaseOwner`).
+
+```ts
+type TypedRun<
+  TInput extends Record<string, unknown> = Record<string, unknown>,
+  TOutput extends Record<string, unknown> | undefined = Record<string, unknown>,
+> = Omit<Run, 'input' | 'output'> & {
+  input: TInput
+  output: TOutput | null
+}
+```
+
+## DurablyEvent
+
+Union type for all SSE events streamed from the server. Useful for custom event handling.
+
+```ts
+type DurablyEvent =
+  | { type: 'run:leased'; runId: string; jobName: string; input: unknown }
+  | {
+      type: 'run:complete'
+      runId: string
+      jobName: string
+      output: unknown
+      duration: number
+    }
+  | { type: 'run:fail'; runId: string; jobName: string; error: string }
+  | { type: 'run:cancel'; runId: string; jobName: string }
+  | { type: 'run:delete'; runId: string; jobName: string }
+  | { type: 'run:trigger'; runId: string; jobName: string; input: unknown }
+  | {
+      type: 'run:coalesced'
+      runId: string
+      jobName: string
+      labels: Record<string, string>
+      skippedInput: unknown
+      skippedLabels: Record<string, string>
+    }
+  | { type: 'run:progress'; runId: string; jobName: string; progress: Progress }
+  | {
+      type: 'step:start'
+      runId: string
+      jobName: string
+      stepName: string
+      stepIndex: number
+    }
+  | {
+      type: 'step:complete'
+      runId: string
+      jobName: string
+      stepName: string
+      stepIndex: number
+      output: unknown
+    }
+  | {
+      type: 'step:cancel'
+      runId: string
+      jobName: string
+      stepName: string
+      stepIndex: number
+      labels: Record<string, string>
+    }
+  | {
+      type: 'log:write'
+      runId: string
+      jobName: string
+      stepName: string | null
+      labels: Record<string, string>
+      level: 'info' | 'warn' | 'error'
+      message: string
+      data: unknown
+    }
+```
+
+All events include `runId` and `jobName`. Unlike core Durably events, SSE events omit `timestamp` and `sequence` — only the fields needed by the UI are sent.
+
 ## StepRecord
 
 ```ts

--- a/website/public/llms.txt
+++ b/website/public/llms.txt
@@ -1314,6 +1314,8 @@ function FilteredDashboard() {
 }
 ```
 
+Return type: `{ runs, page, hasMore, isLoading, nextPage, prevPage, goToPage, refresh }`. Pagination is 0-indexed. Filter semantics: `status` array matches any, `labels` must all match.
+
 ## Server Handler Setup
 
 On your server, use `createDurablyHandler`:


### PR DESCRIPTION
## Summary

Fill documentation gaps found during the #141/#156 review cycle. Only items independent of the React 19 redesign (#160).

- Add `TypedClientRun`, `TypedRun`, `DurablyEvent` type definitions to `types.md`
- Add `createDurablyHandler` options table (`sseThrottleMs`, `onRequest`, `auth`) to `fullstack.md`
- Add `useJobRun` return type table to `spa.md` (including `isCancelled`)
- Clarify filter semantics in both fullstack.md and spa.md: status array = any match, labels = all must match
- Add SPA `useRuns` return type summary to `llms.md`
- Regenerate `llms.txt`

## Test plan

- [x] `pnpm validate` 28/28 pass
- [x] No code changes, docs only

Closes #157

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **ドキュメンテーション**
  * `useRuns` フックのパラメータ仕様とフィルター動作を明確化
  * `useJobRun` フックの戻り値フィールド（ログ、進捗、ステータスフラグ）を追加文書化
  * `createDurablyHandler` の設定オプション（SSEスロットリング、ライフサイクルフック）を文書化

* **新機能**
  * 型安全性を向上させるための新しい TypeScript 型を追加

<!-- end of auto-generated comment: release notes by coderabbit.ai -->